### PR TITLE
Fix - dot-prop vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You can run the script locally using the lambda-local-run python package ( inclu
 
 ```bash
 npm install
+pip install -r requirements.txt
 npx sls invoke local -f cloudwatch-slack --path test_events/event.json --env SLACK_HOOK_URL=https://httpbin.org/post --env SLACK_CHANNEL=test-channel
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,17 +131,17 @@
       "dev": true
     },
     "@serverless/cli": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@serverless/cli/-/cli-1.5.1.tgz",
-      "integrity": "sha512-YUVPGutE8VEbIPCb6aHfePec5kKA1iaiMyLb8snXWYDLy/EWW1Dkff/DiLgeNEy6jqV4n+9lng92re+tMi+U6g==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@serverless/cli/-/cli-1.5.2.tgz",
+      "integrity": "sha512-FMACx0qPD6Uj8U+7jDmAxEe1tdF9DsuY5VsG45nvZ3olC9xYJe/PMwxWsjXfK3tg1HUNywYAGCsy7p5fdXhNzw==",
       "dev": true,
       "requires": {
         "@serverless/core": "^1.1.2",
         "@serverless/template": "^1.1.3",
-        "@serverless/utils": "^1.1.0",
+        "@serverless/utils": "^1.2.0",
         "ansi-escapes": "^4.3.1",
         "chalk": "^2.4.2",
-        "chokidar": "^3.4.0",
+        "chokidar": "^3.4.1",
         "dotenv": "^8.2.0",
         "figures": "^3.2.0",
         "minimist": "^1.2.5",
@@ -186,27 +186,26 @@
       }
     },
     "@serverless/enterprise-plugin": {
-      "version": "3.6.18",
-      "resolved": "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-3.6.18.tgz",
-      "integrity": "sha512-G5krMtCxuJ2yie2Ipn5U2tAdwUUFBixEta2Sj4ilXw+DGgwHqesSGw6buKCfodHwEwkQqcpI5YVf8Qqm+I9Zaw==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-3.7.1.tgz",
+      "integrity": "sha512-+9/gtrSRCXrO/5gLlFO9hZlxl90ctjsDx8dwKHnO9mVMXJ7RQmUWUj+5h2kSrD6bs2F1RmhLgQhwj7DCGEEAQg==",
       "dev": true,
       "requires": {
         "@serverless/event-mocks": "^1.1.1",
-        "@serverless/platform-client": "^1.0.10",
+        "@serverless/platform-client": "^1.1.3",
         "@serverless/platform-sdk": "^2.3.1",
         "chalk": "^2.4.2",
         "child-process-ext": "^2.1.1",
-        "chokidar": "^3.4.1",
+        "chokidar": "^3.4.2",
         "cli-color": "^2.0.0",
         "find-process": "^1.4.3",
-        "flat": "^5.0.0",
+        "flat": "^5.0.2",
         "fs-extra": "^8.1.0",
         "iso8601-duration": "^1.2.0",
-        "isomorphic-fetch": "^2.2.1",
         "js-yaml": "^3.14.0",
         "jsonata": "^1.8.3",
         "jszip": "^3.5.0",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.20",
         "memoizee": "^0.4.14",
         "moment": "^2.27.0",
         "ncjsm": "^4.1.0",
@@ -251,9 +250,9 @@
       }
     },
     "@serverless/platform-client": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-1.1.1.tgz",
-      "integrity": "sha512-vvS8Mn/nKaAIcP4r5wagsU7YoDQ6u5V3DuSOYx6e7fJiZ9vUKPpUbdUovUDxIoANC+Jo4SzuRxfL6MrK8qfZDw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-1.1.3.tgz",
+      "integrity": "sha512-kqJQGsKCYdEJb8l4iWYrbdqmZbs18Xzk60tleBiodI9wNuWdEBOZdTuK6pvIqwpSSzvZqKW2lEdHGfhwmsu0ew==",
       "dev": true,
       "requires": {
         "adm-zip": "^0.4.13",
@@ -269,9 +268,9 @@
       }
     },
     "@serverless/platform-client-china": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-client-china/-/platform-client-china-1.0.30.tgz",
-      "integrity": "sha512-qkiSoe7aPaqLAywUgbREEgSWSgqpX9bC7rhOTd+lMSfHD0AsysscEWKfvlgZMCge3EbfULLbic4jBsAdN64RGA==",
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-client-china/-/platform-client-china-1.0.33.tgz",
+      "integrity": "sha512-Ad/Fy9A6zBGrO4XoaRihl1cdtR3Eh3QX1yIivVz4QR9OgoomrhFXbWEE0BVef7amJZ5nUpmnimFAOhiV7NTZLw==",
       "dev": true,
       "requires": {
         "@serverless/utils-china": "^0.1.19",
@@ -409,9 +408,9 @@
       }
     },
     "@serverless/utils-china": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/@serverless/utils-china/-/utils-china-0.1.22.tgz",
-      "integrity": "sha512-TYI1khc2Is3ESNwR2QrQx0fo8PfJto0IlDV3qgvfZ5ovCjPG6Ql1ziO8BpzDs5DgAO4TeNuwo28LJOUw/ANiKg==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@serverless/utils-china/-/utils-china-0.1.26.tgz",
+      "integrity": "sha512-XsoB4NZIsHvMXzlSHGOZdQk2iR7Nt96JQqCGRJhCx7mfwd/J636eIB5GYjecz6bzhc7XkEOw3kW6xhC+G5expw==",
       "dev": true,
       "requires": {
         "@tencent-sdk/capi": "^0.2.17",
@@ -489,9 +488,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.158",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.158.tgz",
-      "integrity": "sha512-InCEXJNTv/59yO4VSfuvNrZHt7eeNtWQEgnieIA+mIC+MOWM9arOWG2eQ8Vhk6NbOre6/BidiXhkZYeDY9U35w==",
+      "version": "4.14.160",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.160.tgz",
+      "integrity": "sha512-aP03BShJoO+WVndoVj/WNcB/YBPt+CIU1mvaao2GRAHy2yg4pT/XS4XnVHEQBjPJGycWf/9seKEO9vopTJGkvA==",
       "dev": true
     },
     "@types/long": {
@@ -507,9 +506,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
-      "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==",
+      "version": "14.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
+      "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==",
       "dev": true
     },
     "@types/object-assign": {
@@ -584,9 +583,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -594,6 +593,12 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -901,9 +906,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.725.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.725.0.tgz",
-      "integrity": "sha512-Qd/MlxfQC9NpTxFUQ7u2BdsjiwNtbn5oVp04NPfXEc0xyT216TtcIs+jNyiJ9WaH7AgkHouU1BbBcReO8byYzg==",
+      "version": "2.739.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.739.0.tgz",
+      "integrity": "sha512-N2XyxY12gs0GJc26O8TmdT30ovEKWsPX787CNW24g0cXTCyc/Teltq0re6yGxfaH0VmN6qONNLr3E59JtJ3neA==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -949,9 +954,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
       "dev": true
     },
     "axios": {
@@ -1247,9 +1252,9 @@
       },
       "dependencies": {
         "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -1342,9 +1347,9 @@
       }
     },
     "chokidar": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
-      "integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+      "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
@@ -1656,12 +1661,12 @@
       }
     },
     "configstore": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
-      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.5.tgz",
+      "integrity": "sha512-nlOhI4+fdzoK5xmJ+NY+1gZK56bwEaWZr8fYuXohZ9Vkc1o3a4T/R3M+yE/w7x/ZVJ1zF8c+oaOvF0dztdUgmA==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.1.0",
+        "dot-prop": "^4.2.1",
         "graceful-fs": "^4.1.2",
         "make-dir": "^1.0.0",
         "unique-string": "^1.0.0",
@@ -1793,9 +1798,9 @@
       }
     },
     "dayjs": {
-      "version": "1.8.31",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.31.tgz",
-      "integrity": "sha512-mPh1mslned+5PuIuiUfbw4CikHk6AEAf2Baxih+wP5fssv+wmlVhvgZ7mq+BhLt7Sr/Hc8leWDiwe6YnrpNt3g==",
+      "version": "1.8.34",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.34.tgz",
+      "integrity": "sha512-Olb+E6EoMvdPmAMq2QoucuyZycKHjTlBXmRx8Ada+wGtq4SIXuDCdtoaX4KkK0yjf1fJLnwXQURr8gQKWKaybw==",
       "dev": true
     },
     "debug": {
@@ -2112,9 +2117,9 @@
       }
     },
     "dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+      "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
       "dev": true,
       "requires": {
         "is-obj": "^1.0.0"
@@ -2913,13 +2918,10 @@
       }
     },
     "flat": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.0.tgz",
-      "integrity": "sha512-6KSMM+cHHzXC/hpldXApL2S8Uz+QZv+tq5o/L0KQYleoG+GcwrnIJhTWC7tCOiKQp8D/fIvryINU1OZCCwevjA==",
-      "dev": true,
-      "requires": {
-        "is-buffer": "~2.0.4"
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
     },
     "follow-redirects": {
       "version": "1.5.10",
@@ -3293,12 +3295,6 @@
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         },
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
-        },
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -3488,12 +3484,6 @@
         "kind-of": "^4.0.0"
       },
       "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
-        },
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -3674,6 +3664,35 @@
         }
       }
     },
+    "inquirer-autocomplete-prompt": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-1.0.2.tgz",
+      "integrity": "sha512-vNmAhhrOQwPnUm4B9kz1UB7P98rVF1z8txnjp53r40N0PBCuqoRWqjg3Tl0yz0UkDg7rEUtZ2OZpNc7jnOU9Zw==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "figures": "^2.0.0",
+        "run-async": "^2.3.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+          "dev": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        }
+      }
+    },
     "into-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
@@ -3693,12 +3712,6 @@
         "kind-of": "^3.0.2"
       },
       "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
-        },
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -3726,9 +3739,9 @@
       }
     },
     "is-buffer": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-ci": {
@@ -3749,12 +3762,6 @@
         "kind-of": "^3.0.2"
       },
       "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
-        },
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -4340,9 +4347,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.defaults": {
@@ -4789,12 +4796,6 @@
             "is-descriptor": "^0.1.0"
           }
         },
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
-        },
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -4861,9 +4862,9 @@
       }
     },
     "open": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.1.0.tgz",
-      "integrity": "sha512-lLPI5KgOwEYCDKXf4np7y1PBEkj7HYIyP2DY8mVDRnx0VIIu6bNrRB0R66TuO7Mack6EnTNLm4uvcl1UoklTpA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.2.0.tgz",
+      "integrity": "sha512-4HeyhxCvBTI5uBePsAdi55C5fmqnWZ2e2MlmvWi5KW5tdH5rxoiv/aMtbeVxKZc3eWkT1GymMnLG8XC4Rq4TDQ==",
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0",
@@ -4871,9 +4872,9 @@
       },
       "dependencies": {
         "is-docker": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
-          "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+          "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
           "dev": true
         }
       }
@@ -5505,26 +5506,28 @@
       "dev": true
     },
     "serverless": {
-      "version": "1.77.1",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-1.77.1.tgz",
-      "integrity": "sha512-K+NFc1NNkah5ilSi+GCn7D6XOr+x6ieWRZMx8mmCWshi4p/MiEZ8WZ4F2Viu5bRQ/3dmrjTMjMlc5PnTwHfZIg==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-1.79.0.tgz",
+      "integrity": "sha512-9MONfHEZgklkniu7fQ/pnZwToSEIlA6SGNPQy3uEE/3p33hzGcZUI3dpWbkUeOKFS5LQ74q9hMMbk+RYFJITRA==",
       "dev": true,
       "requires": {
-        "@serverless/cli": "^1.5.1",
-        "@serverless/components": "^2.33.0",
-        "@serverless/enterprise-plugin": "^3.6.18",
+        "@serverless/cli": "^1.5.2",
+        "@serverless/components": "^2.34.6",
+        "@serverless/enterprise-plugin": "^3.7.1",
         "@serverless/inquirer": "^1.1.2",
         "@serverless/utils": "^1.2.0",
+        "ajv": "^6.12.4",
+        "ajv-keywords": "^3.5.2",
         "archiver": "^3.1.1",
         "async": "^1.5.2",
-        "aws-sdk": "^2.721.0",
+        "aws-sdk": "^2.736.0",
         "bluebird": "^3.7.2",
         "boxen": "^3.2.0",
         "cachedir": "^2.3.0",
         "chalk": "^2.4.2",
         "child-process-ext": "^2.1.1",
         "d": "^1.0.1",
-        "dayjs": "^1.8.30",
+        "dayjs": "^1.8.33",
         "decompress": "^4.2.1",
         "download": "^7.1.0",
         "essentials": "^1.1.1",
@@ -5541,7 +5544,7 @@
         "json-cycle": "^1.3.0",
         "json-refs": "^3.0.15",
         "jwt-decode": "^2.2.0",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.20",
         "memoizee": "^0.4.14",
         "mkdirp": "^0.5.4",
         "nanomatch": "^1.2.13",
@@ -5566,21 +5569,21 @@
       },
       "dependencies": {
         "@serverless/components": {
-          "version": "2.33.2",
-          "resolved": "https://registry.npmjs.org/@serverless/components/-/components-2.33.2.tgz",
-          "integrity": "sha512-AFoJgoya9cYQrDVeyI22RI1+6HNbnKbZ/pputugF87zpUM9mOdZZX4K85bH7w7QeVFARWcYQx7kNxENZcuQ7lQ==",
+          "version": "2.34.7",
+          "resolved": "https://registry.npmjs.org/@serverless/components/-/components-2.34.7.tgz",
+          "integrity": "sha512-zQ5S/DjqYKgcUUA/FJGr09m5cQ59eXWMXUoKanZAAmpaAfpvD5uaLbGGlgdIli6JZTks5hLqtjfcar87r94/qg==",
           "dev": true,
           "requires": {
             "@serverless/inquirer": "^1.1.2",
-            "@serverless/platform-client": "^1.0.6",
-            "@serverless/platform-client-china": "^1.0.28",
+            "@serverless/platform-client": "^1.1.3",
+            "@serverless/platform-client-china": "^1.0.32",
             "@serverless/platform-sdk": "^2.3.1",
-            "@serverless/utils": "^1.1.0",
-            "adm-zip": "^0.4.14",
+            "@serverless/utils": "^1.2.0",
+            "adm-zip": "^0.4.16",
             "ansi-escapes": "^4.3.1",
             "chalk": "^2.4.2",
             "child-process-ext": "^2.1.1",
-            "chokidar": "^3.4.0",
+            "chokidar": "^3.4.1",
             "dotenv": "^8.2.0",
             "figures": "^3.2.0",
             "fs-extra": "^8.1.0",
@@ -5589,10 +5592,11 @@
             "graphlib": "^2.1.8",
             "https-proxy-agent": "^5.0.0",
             "ini": "^1.3.5",
+            "inquirer-autocomplete-prompt": "^1.0.2",
             "js-yaml": "^3.14.0",
             "minimist": "^1.2.5",
             "moment": "^2.27.0",
-            "open": "^7.0.4",
+            "open": "^7.1.0",
             "prettyoutput": "^1.2.0",
             "ramda": "^0.26.1",
             "semver": "^7.3.2",
@@ -5600,7 +5604,7 @@
             "strip-ansi": "^5.2.0",
             "traverse": "^0.6.6",
             "uuid": "^3.4.0",
-            "ws": "^7.3.0"
+            "ws": "^7.3.1"
           },
           "dependencies": {
             "globby": {
@@ -5893,12 +5897,6 @@
         "kind-of": "^3.2.0"
       },
       "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
-        },
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -6023,9 +6021,9 @@
       }
     },
     "split2": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
-      "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "dev": true,
       "requires": {
         "readable-stream": "^3.0.0"
@@ -6391,12 +6389,6 @@
         "kind-of": "^3.0.2"
       },
       "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
-        },
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -6488,9 +6480,9 @@
       "dev": true
     },
     "type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-      "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
+      "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==",
       "dev": true
     },
     "type-fest": {
@@ -6716,9 +6708,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.2.0.tgz",
-      "integrity": "sha512-SdGPoQMMnzVYThUbSrEvqTlkvC1Ux27NehaJ/GUHBfNrh5Mjg+1/uRyFMwVnxO2MrikMWvWAqUGgQOfVU4hT7w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz",
+      "integrity": "sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/codeontap/lambda-cloudwatch-slack#readme",
   "devDependencies": {
-    "serverless": "^1.77.1",
+    "serverless": "^1.79.0",
     "serverless-python-requirements": "^5.1.0"
   }
 }


### PR DESCRIPTION
[Dependabot alert](https://github.com/hamlet-io/lambda-cloudwatch-slack/network/alert/package-lock.json/dot-prop/open)

Updated dependencies with `npm update`, reinstalled and tested on private slack group. Dependencies now specify a version above the recommended.

Updated the README to include installation of pip packages.