### PR TITLE
fix(deps): deps update to resolve vuln in bl pkg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -186,13 +186,13 @@
       }
     },
     "@serverless/enterprise-plugin": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-3.7.1.tgz",
-      "integrity": "sha512-+9/gtrSRCXrO/5gLlFO9hZlxl90ctjsDx8dwKHnO9mVMXJ7RQmUWUj+5h2kSrD6bs2F1RmhLgQhwj7DCGEEAQg==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-3.8.2.tgz",
+      "integrity": "sha512-tJqvVBHOQk110UXEO/RVeZIUh/tyBlxalaNnGRiTsbT2kRsq0s/OfznfMufANmlKaKPcoOXxHEW8oaAV4N1XyA==",
       "dev": true,
       "requires": {
         "@serverless/event-mocks": "^1.1.1",
-        "@serverless/platform-client": "^1.1.3",
+        "@serverless/platform-client": "^1.1.8",
         "@serverless/platform-sdk": "^2.3.1",
         "chalk": "^2.4.2",
         "child-process-ext": "^2.1.1",
@@ -250,9 +250,9 @@
       }
     },
     "@serverless/platform-client": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-1.1.3.tgz",
-      "integrity": "sha512-kqJQGsKCYdEJb8l4iWYrbdqmZbs18Xzk60tleBiodI9wNuWdEBOZdTuK6pvIqwpSSzvZqKW2lEdHGfhwmsu0ew==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-1.1.8.tgz",
+      "integrity": "sha512-DmU71Lh0ALOMumGD7k2HfO6WwaFpJCA4ech1S9Kd8AQvpKZrT8fyUl9Ymc/E6GJLRC4s3a5wzcsLbu5AiDNyHA==",
       "dev": true,
       "requires": {
         "adm-zip": "^0.4.13",
@@ -268,12 +268,12 @@
       }
     },
     "@serverless/platform-client-china": {
-      "version": "1.0.33",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-client-china/-/platform-client-china-1.0.33.tgz",
-      "integrity": "sha512-Ad/Fy9A6zBGrO4XoaRihl1cdtR3Eh3QX1yIivVz4QR9OgoomrhFXbWEE0BVef7amJZ5nUpmnimFAOhiV7NTZLw==",
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-client-china/-/platform-client-china-1.0.37.tgz",
+      "integrity": "sha512-eN2UBK51Z9RkRY5Im0j2wCl3XuHBKiuY3kpQIxtGs52yuQx8PA0I/HBsYwyRgoTpvATK3MM/SsyeKpvNs90+uw==",
       "dev": true,
       "requires": {
-        "@serverless/utils-china": "^0.1.19",
+        "@serverless/utils-china": "^0.1.27",
         "archiver": "^4.0.1",
         "dotenv": "^8.2.0",
         "fs-extra": "^8.1.0",
@@ -408,9 +408,9 @@
       }
     },
     "@serverless/utils-china": {
-      "version": "0.1.26",
-      "resolved": "https://registry.npmjs.org/@serverless/utils-china/-/utils-china-0.1.26.tgz",
-      "integrity": "sha512-XsoB4NZIsHvMXzlSHGOZdQk2iR7Nt96JQqCGRJhCx7mfwd/J636eIB5GYjecz6bzhc7XkEOw3kW6xhC+G5expw==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@serverless/utils-china/-/utils-china-0.1.27.tgz",
+      "integrity": "sha512-ZQDTtmFBD2xl23YFFMVOTmqsgqtcxk9WKBGdixZ3ZY2MxAjrNJvBE0vPCRsYrQCs0I+TzdPDRIPSrOUJh7cpiw==",
       "dev": true,
       "requires": {
         "@tencent-sdk/capi": "^0.2.17",
@@ -488,9 +488,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.160",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.160.tgz",
-      "integrity": "sha512-aP03BShJoO+WVndoVj/WNcB/YBPt+CIU1mvaao2GRAHy2yg4pT/XS4XnVHEQBjPJGycWf/9seKEO9vopTJGkvA==",
+      "version": "4.14.161",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
+      "integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==",
       "dev": true
     },
     "@types/long": {
@@ -506,9 +506,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
-      "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==",
+      "version": "14.6.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.3.tgz",
+      "integrity": "sha512-pC/hkcREG6YfDfui1FBmj8e20jFU5Exjw4NYDm8kEdrW+mOh0T1Zve8DWKnS7ZIZvgncrctcNCXF4Q2I+loyww==",
       "dev": true
     },
     "@types/object-assign": {
@@ -681,15 +681,6 @@
         "zip-stream": "^2.1.2"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
         "compress-commons": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
@@ -882,10 +873,13 @@
       "dev": true
     },
     "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
     },
     "async-limiter": {
       "version": "1.0.1",
@@ -906,9 +900,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.739.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.739.0.tgz",
-      "integrity": "sha512-N2XyxY12gs0GJc26O8TmdT30ovEKWsPX787CNW24g0cXTCyc/Teltq0re6yGxfaH0VmN6qONNLr3E59JtJ3neA==",
+      "version": "2.745.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.745.0.tgz",
+      "integrity": "sha512-YTmDvxb0foJC/iZOSsn+MdO4g9nPnlyRdhIpFqvPUkrFzWn5rP4mPtDJan2Eu0j4R02pdwfDhmvr82ckH2w7OQ==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -1072,9 +1066,9 @@
       "dev": true
     },
     "bl": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
       "dev": true,
       "requires": {
         "buffer": "^5.5.0",
@@ -1126,9 +1120,9 @@
           "dev": true
         },
         "cli-boxes": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
-          "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+          "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
           "dev": true
         },
         "string-width": {
@@ -1798,9 +1792,9 @@
       }
     },
     "dayjs": {
-      "version": "1.8.34",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.34.tgz",
-      "integrity": "sha512-Olb+E6EoMvdPmAMq2QoucuyZycKHjTlBXmRx8Ada+wGtq4SIXuDCdtoaX4KkK0yjf1fJLnwXQURr8gQKWKaybw==",
+      "version": "1.8.35",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.35.tgz",
+      "integrity": "sha512-isAbIEenO4ilm6f8cpqvgjZCsuerDAz2Kb7ri201AiNn58aqXuaLJEnCtfIMdCvERZHNGRY5lDMTr/jdAnKSWQ==",
       "dev": true
     },
     "debug": {
@@ -3665,30 +3659,66 @@
       }
     },
     "inquirer-autocomplete-prompt": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-1.0.2.tgz",
-      "integrity": "sha512-vNmAhhrOQwPnUm4B9kz1UB7P98rVF1z8txnjp53r40N0PBCuqoRWqjg3Tl0yz0UkDg7rEUtZ2OZpNc7jnOU9Zw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-1.1.0.tgz",
+      "integrity": "sha512-mrSeUSFGnTSid/DCKG+E+IcN4MaOnT2bW7NuSagZAguD4k3hZ0UladdYNP4EstZOwgeqv0C3M1zYa1QIIf0Oyg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "figures": "^2.0.0",
-        "run-async": "^2.3.0"
+        "ansi-escapes": "^4.3.1",
+        "chalk": "^4.0.0",
+        "figures": "^3.2.0",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.2"
       },
       "dependencies": {
-        "ansi-escapes": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-          "dev": true
-        },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -4862,9 +4892,9 @@
       }
     },
     "open": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.2.0.tgz",
-      "integrity": "sha512-4HeyhxCvBTI5uBePsAdi55C5fmqnWZ2e2MlmvWi5KW5tdH5rxoiv/aMtbeVxKZc3eWkT1GymMnLG8XC4Rq4TDQ==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.2.1.tgz",
+      "integrity": "sha512-xbYCJib4spUdmcs0g/2mK1nKo/jO2T7INClWd/beL7PFkXRWgr8B23ssDHX/USPn2M2IjDR5UdpYs6I67SnTSA==",
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0",
@@ -5152,9 +5182,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
-          "integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==",
+          "version": "13.13.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.16.tgz",
+          "integrity": "sha512-dJ9vXxJ8MEwzNn4GkoAGauejhXoKuJyYKegsA6Af25ZpEDXomeVXt5HUWUNVHk5UN7+U0f6ghC6otwt+7PdSDg==",
           "dev": true
         }
       }
@@ -5506,28 +5536,27 @@
       "dev": true
     },
     "serverless": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-1.79.0.tgz",
-      "integrity": "sha512-9MONfHEZgklkniu7fQ/pnZwToSEIlA6SGNPQy3uEE/3p33hzGcZUI3dpWbkUeOKFS5LQ74q9hMMbk+RYFJITRA==",
+      "version": "1.81.1",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-1.81.1.tgz",
+      "integrity": "sha512-CaNAEFDc1V7egtIcJcF5A7ba6ipD9FG0ZPbHr0M4m8IMsmfWAewdhhj1BdlcpaD16mNZH9bjXYT28z+mHKZ4/w==",
       "dev": true,
       "requires": {
         "@serverless/cli": "^1.5.2",
-        "@serverless/components": "^2.34.6",
-        "@serverless/enterprise-plugin": "^3.7.1",
+        "@serverless/components": "^2.34.9",
+        "@serverless/enterprise-plugin": "^3.8.2",
         "@serverless/inquirer": "^1.1.2",
         "@serverless/utils": "^1.2.0",
         "ajv": "^6.12.4",
         "ajv-keywords": "^3.5.2",
         "archiver": "^3.1.1",
-        "async": "^1.5.2",
-        "aws-sdk": "^2.736.0",
+        "aws-sdk": "^2.744.0",
         "bluebird": "^3.7.2",
         "boxen": "^3.2.0",
         "cachedir": "^2.3.0",
         "chalk": "^2.4.2",
         "child-process-ext": "^2.1.1",
         "d": "^1.0.1",
-        "dayjs": "^1.8.33",
+        "dayjs": "^1.8.35",
         "decompress": "^4.2.1",
         "download": "^7.1.0",
         "essentials": "^1.1.1",
@@ -5559,7 +5588,8 @@
         "semver-regex": "^2.0.0",
         "stream-promise": "^3.2.0",
         "tabtab": "^3.0.2",
-        "type": "^2.0.0",
+        "timers-ext": "^0.1.7",
+        "type": "^2.1.0",
         "untildify": "^3.0.3",
         "update-notifier": "^2.5.0",
         "uuid": "^3.4.0",
@@ -5569,14 +5599,14 @@
       },
       "dependencies": {
         "@serverless/components": {
-          "version": "2.34.7",
-          "resolved": "https://registry.npmjs.org/@serverless/components/-/components-2.34.7.tgz",
-          "integrity": "sha512-zQ5S/DjqYKgcUUA/FJGr09m5cQ59eXWMXUoKanZAAmpaAfpvD5uaLbGGlgdIli6JZTks5hLqtjfcar87r94/qg==",
+          "version": "2.34.9",
+          "resolved": "https://registry.npmjs.org/@serverless/components/-/components-2.34.9.tgz",
+          "integrity": "sha512-qFjIeGgR4SjS32Tbl4BvoxOtLpv3Vx4s/81HdmmpdIrMPe7ePGUfkBVBu3axxAXHf4ajlb4WC1HmhTmZAHHSLQ==",
           "dev": true,
           "requires": {
             "@serverless/inquirer": "^1.1.2",
             "@serverless/platform-client": "^1.1.3",
-            "@serverless/platform-client-china": "^1.0.32",
+            "@serverless/platform-client-china": "^1.0.37",
             "@serverless/platform-sdk": "^2.3.1",
             "@serverless/utils": "^1.2.0",
             "adm-zip": "^0.4.16",
@@ -6622,9 +6652,9 @@
       }
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -6752,17 +6782,6 @@
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
         "winston-transport": "^4.3.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        }
       }
     },
     "winston-transport": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/codeontap/lambda-cloudwatch-slack#readme",
   "devDependencies": {
-    "serverless": "^1.79.0",
+    "serverless": "^1.81.1",
     "serverless-python-requirements": "^5.1.0"
   }
 }


### PR DESCRIPTION
`npm update` on product.
Addresses a known vulnerability in the `bl` dependency:

> CVE-2020-8244
high severity
Vulnerable versions: >= 4.0.0, < 4.0.3
Patched version: 4.0.3
A buffer over-read vulnerability exists in bl <4.0.3, <3.0.1 and <2.2.1 which could allow an attacker to supply user input (even typed) that if it ends up in consume() argument and can become negative, the BufferList state can be corrupted, tricking it into exposing uninitialized memory via regular .slice() calls.

Testing was successful.