### PR TITLE
fix: set default color to ERROR

### DIFF
--- a/cloudwatch-slack/lambda_function.py
+++ b/cloudwatch-slack/lambda_function.py
@@ -68,7 +68,7 @@ def lambda_handler(event, context):
     else:
         color = LEVEL_TO_COLOR.get(
                     alarm_severity,
-                    'ERROR')
+                    LEVEL_TO_COLOR['ERROR'])
 
     alarm_description = message['AlarmDescription']
     if 'Namespace' in message['Trigger']:


### PR DESCRIPTION
This PR adds a minor fix for the correct colour default value in cases when there is no match for alarm severity in `LEVEL_TO_COLOR` map.